### PR TITLE
Add onFulfill and new tests

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,19 +1,17 @@
-import createAsyncSelector from '../src/index';
-import _ from '../src/underscore';
-
+import createAsyncSelector from "../src/index";
+import _ from "../src/underscore";
 
 const state = {
-  text: "Ma",
-}
+  text: "Ma"
+};
 let count = 0;
 
 function getEmployees(text) {
-
   return new Promise((resolve, reject) => {
     setTimeout(() => {
       const database = ["Mark Metzger", "Steven Miller"];
       if (text.length > 10) {
-        reject('Search Text Too Long');
+        reject("Search Text Too Long");
       } else {
         resolve(database.filter(name => name.includes(text)));
       }
@@ -26,108 +24,112 @@ function deepEqual(a, b) {
 }
 
 const params = {
-  sync:(text) => [],
-  async: getEmployees,
-}
+  sync: text => [],
+  async: getEmployees
+};
 
-test('Test createAsyncSelector is function', () => {
-  expect(typeof createAsyncSelector === 'function').toBe(true);
+test("Test createAsyncSelector is function", () => {
+  expect(typeof createAsyncSelector === "function").toBe(true);
 });
 
-test('Test createAsyncSelector default value', () => {
+test("Test createAsyncSelector default value", () => {
   const employees = createAsyncSelector(params, state => state.text);
 
-  const expected = { 
+  const expected = {
     value: [],
     previous: undefined,
     isWaiting: true,
     isResolved: false,
-    isRejected: false 
-  }
+    isRejected: false
+  };
   expect(deepEqual(employees(state), expected)).toBe(true);
 });
 
-test('Test createAsyncSelector async value', done => {
+test("Test createAsyncSelector async value", done => {
   const employees = createAsyncSelector(params, state => state.text);
 
-  const expected = { 
+  const expected = {
     value: ["Mark Metzger"],
     previous: ["Mark Metzger"],
     isWaiting: false,
     isResolved: true,
-    isRejected: false 
-  }
-  employees(state)
+    isRejected: false
+  };
+  employees(state);
   setTimeout(() => {
     try {
       expect(deepEqual(employees(state), expected)).toBe(true);
     } catch (e) {
-      done.fail(e)
+      done.fail(e);
     }
     done();
-  }, 200)
-  
+  }, 200);
 });
 
-test('Test createAsyncSelector previous value', done => {
+test("Test createAsyncSelector previous value", done => {
   const employees = createAsyncSelector(params, state => state.text);
 
-  const expected = { 
+  const expected = {
     value: ["Steven Miller"],
     previous: ["Steven Miller"],
     isWaiting: false,
     isResolved: true,
-    isRejected: false 
-  }
+    isRejected: false
+  };
 
-  employees(state)
+  employees(state);
   setTimeout(() => {
-    employees(state)
+    employees(state);
     state.text = "St";
     employees(state);
     setTimeout(() => {
       try {
         expect(deepEqual(employees(state), expected)).toBe(true);
       } catch (e) {
-        done.fail(e)
+        done.fail(e);
       }
-      done()
-    }, 200)
-  }, 200)
+      done();
+    }, 200);
+  }, 200);
 });
 
-test('Test createAsyncSelector rejected', done => {
+test("Test createAsyncSelector rejected", done => {
   const employees = createAsyncSelector(params, state => state.text);
-  const state = {text: 'Mar'};
-  const expected = { 
+  const state = { text: "Mar" };
+  const expected = {
     value: "Search Text Too Long",
     previous: ["Mark Metzger"],
     isWaiting: false,
     isResolved: false,
-    isRejected: true 
-  }
+    isRejected: true
+  };
 
-  employees(state)
+  employees(state);
   setTimeout(() => {
-    employees(state)
+    employees(state);
     state.text = "Sttttttttttttt";
     employees(state);
     setTimeout(() => {
       try {
         expect(deepEqual(employees(state), expected)).toBe(true);
       } catch (e) {
-        done.fail(e)
+        done.fail(e);
       }
-      done()
-    }, 200)
-  }, 200)
+      done();
+    }, 200);
+  }, 200);
 });
 
-test('memoization', () => {
+test("memoization", () => {
   let count = 0;
-  let state = {text: 'gg'}
-  const sync = () => {count += 1};
-  const employees = createAsyncSelector({...params, sync}, state => state.text);
+  let state = { text: "gg" };
+  const sync = () => {
+    count += 1;
+  };
+  const employees = createAsyncSelector(
+    { ...params, sync },
+    state => state.text
+  );
 
   count = 0;
   employees(state);
@@ -137,9 +139,14 @@ test('memoization', () => {
   expect(count).toBe(2);
 });
 
-test('memoization', () => {
-  const sync = () => {count += 1};
-  const employees = createAsyncSelector({...params, sync}, state => state.text);
+test("memoization", () => {
+  const sync = () => {
+    count += 1;
+  };
+  const employees = createAsyncSelector(
+    { ...params, sync },
+    state => state.text
+  );
 
   count = 0;
   employees(state);
@@ -148,9 +155,14 @@ test('memoization', () => {
   expect(count).toBe(1);
 });
 
-test('lack of memoization', () => {
-  const sync = () => {count += 1};
-  const employees = createAsyncSelector({...params, sync}, state => state.text);
+test("lack of memoization", () => {
+  const sync = () => {
+    count += 1;
+  };
+  const employees = createAsyncSelector(
+    { ...params, sync },
+    state => state.text
+  );
 
   count = 0;
   employees(state);
@@ -159,9 +171,14 @@ test('lack of memoization', () => {
   expect(count).toBe(3);
 });
 
-test('cancel', () => {
-  const onCancel = () => {count += 1};
-  const employees = createAsyncSelector({...params, onCancel}, state => state.text);
+test("cancel", () => {
+  const onCancel = () => {
+    count += 1;
+  };
+  const employees = createAsyncSelector(
+    { ...params, onCancel },
+    state => state.text
+  );
 
   count = 0;
   employees(state);
@@ -170,9 +187,14 @@ test('cancel', () => {
   expect(count).toBe(2);
 });
 
-test('cancel', done => {
-  const onCancel = () => {count += 1};
-  const employees = createAsyncSelector({...params, onCancel}, state => state.text);
+test("cancel", done => {
+  const onCancel = () => {
+    count += 1;
+  };
+  const employees = createAsyncSelector(
+    { ...params, onCancel },
+    state => state.text
+  );
 
   count = 0;
   employees(state);
@@ -182,22 +204,29 @@ test('cancel', done => {
     try {
       expect(count).toBe(1);
     } catch (e) {
-      done.fail(e)
+      done.fail(e);
     }
-    done()
-    
+    done();
   }, 500);
 });
 
-test('omitStatus', () => {
+test("omitStatus", () => {
   const omitStatus = true;
-  const employees = createAsyncSelector({...params, omitStatus}, state => state.text);
+  const employees = createAsyncSelector(
+    { ...params, omitStatus },
+    state => state.text
+  );
   expect(deepEqual(employees(state), [])).toBe(true);
 });
 
-test('onResolve', () => {
-  const onResolve = () => {count += 1};
-  const employees = createAsyncSelector({...params, onResolve}, state => state.text);
+test("onResolve", () => {
+  const onResolve = () => {
+    count += 1;
+  };
+  const employees = createAsyncSelector(
+    { ...params, onResolve },
+    state => state.text
+  );
   count = 0;
   employees(state);
   employees(state);
@@ -205,11 +234,16 @@ test('onResolve', () => {
   expect(count).toBe(0);
 });
 
-test('onResolve', done => {
+test("onResolve", done => {
   let count = 0;
-  const onResolve = () => {count += 1};
-  const employees = createAsyncSelector({...params, onResolve}, state => state.text);
-  
+  const onResolve = () => {
+    count += 1;
+  };
+  const employees = createAsyncSelector(
+    { ...params, onResolve },
+    state => state.text
+  );
+
   employees(state);
   setTimeout(() => {
     employees(state);
@@ -219,18 +253,100 @@ test('onResolve', done => {
         try {
           expect(count).toBe(1);
         } catch (e) {
-          done.fail(e)
+          done.fail(e);
         }
-        done()
+        done();
       }, 200);
     }, 200);
   }, 200);
 });
 
-test('onResolve forceUpdate', done => {
+test("onFulfill", () => {
+  const onFulfill = () => {
+    count += 1;
+  };
+  const employees = createAsyncSelector(
+    { ...params, onFulfill },
+    state => state.text
+  );
+  count = 0;
+  employees(state);
+  employees(state);
+  employees(state);
+  expect(count).toBe(0);
+});
+
+test("onFulfill should run after onResolve", done => {
   let count = 0;
-  const onResolve = () => {count += 1};
-  const employees = createAsyncSelector({...params, onResolve}, state => state.text);
+  const onResolve = () => {
+    count += 1;
+  };
+  const onFulfill = () => {
+    count += 2;
+  };
+  const employees = createAsyncSelector(
+    { ...params, onResolve, onFulfill },
+    state => state.text
+  );
+
+  employees(state);
+  setTimeout(() => {
+    employees(state);
+    setTimeout(() => {
+      employees(state);
+      setTimeout(() => {
+        try {
+          expect(count).toBe(3);
+        } catch (e) {
+          done.fail(e);
+        }
+        done();
+      }, 200);
+    }, 200);
+  }, 200);
+});
+
+test("onFulfill should run after onReject", done => {
+  let state = { employees: ["Mark Metzger"], maxAge: 1 };
+  let result = null;
+  let fulfilled = false;
+  const onReject = (r, n, a) => {
+    result = [r, n, a];
+
+  };
+  const onFulfill = () => {
+    fulfilled = true;
+  };
+  onReject(state);
+
+  const ages = createAsyncSelector(
+    { ...params2, onReject, onFulfill },
+    s => s.employees,
+    s => s.maxAge
+  );
+
+  ages(state);
+  ages(state);
+  setTimeout(() => {
+    try {
+      expect(deepEqual(result, ['too young', ['Mark Metzger'], 1])).toBe(true);
+      expect(deepEqual(fulfilled, true)).toBe(true);
+    } catch (e) {
+      done.fail(e);
+    }
+    done();
+  }, 200);
+});
+
+test("onResolve forceUpdate", done => {
+  let count = 0;
+  const onResolve = () => {
+    count += 1;
+  };
+  const employees = createAsyncSelector(
+    { ...params, onResolve },
+    state => state.text
+  );
   count = 0;
   employees(state);
   setTimeout(() => {
@@ -241,18 +357,23 @@ test('onResolve forceUpdate', done => {
         try {
           expect(count).toBe(3);
         } catch (e) {
-          done.fail(e)
+          done.fail(e);
         }
-        done()
+        done();
       }, 200);
     }, 200);
   }, 200);
 });
 
-test('onResolve', done => {
+test("onResolve", done => {
   let count = 0;
-  const onResolve = () => {count += 1};
-  const employees = createAsyncSelector({...params, onResolve}, state => state.text);
+  const onResolve = () => {
+    count += 1;
+  };
+  const employees = createAsyncSelector(
+    { ...params, onResolve },
+    state => state.text
+  );
   employees(state);
   setTimeout(() => {
     employees(state);
@@ -262,35 +383,40 @@ test('onResolve', done => {
         try {
           expect(count).toBe(2);
         } catch (e) {
-          done.fail(e)
+          done.fail(e);
         }
-        done()
+        done();
       }, 200);
     }, 200);
   }, 10);
 });
 
-test('debounce', done => {
+test("debounce", done => {
   let c = 0;
   const throttle = f => _.debounce(f, 300);
-  const onResolve = () => {c += 1};
-  const employees = createAsyncSelector({...params, onResolve, throttle}, state => state.text);
-  employees({text: 'a'});
+  const onResolve = () => {
+    c += 1;
+  };
+  const employees = createAsyncSelector(
+    { ...params, onResolve, throttle },
+    state => state.text
+  );
+  employees({ text: "a" });
   setTimeout(() => {
-    employees({text: 'b'});
+    employees({ text: "b" });
     setTimeout(() => {
-      employees({text: 'c'});
+      employees({ text: "c" });
       setTimeout(() => {
-        employees({text: 'd'});
+        employees({ text: "d" });
         setTimeout(() => {
-          employees({text: 'e'});
+          employees({ text: "e" });
           setTimeout(() => {
             try {
               expect(c).toBe(1);
             } catch (e) {
-              done.fail(e)
+              done.fail(e);
             }
-            done()
+            done();
           }, 400);
         }, 400);
       }, 200);
@@ -298,27 +424,32 @@ test('debounce', done => {
   }, 200);
 });
 
-test('debounce', done => {
+test("debounce", done => {
   let c = 0;
   const throttle = f => _.debounce(f, 300);
-  const onResolve = () => {c += 1};
-  const employees = createAsyncSelector({...params, onResolve, throttle}, state => state.text);
-  employees({text: 'a'});
+  const onResolve = () => {
+    c += 1;
+  };
+  const employees = createAsyncSelector(
+    { ...params, onResolve, throttle },
+    state => state.text
+  );
+  employees({ text: "a" });
   setTimeout(() => {
-    employees({text: 'b'});
+    employees({ text: "b" });
     setTimeout(() => {
-      employees({text: 'c'});
+      employees({ text: "c" });
       setTimeout(() => {
-        employees({text: 'd'});
+        employees({ text: "d" });
         setTimeout(() => {
-          employees({text: 'e'});
+          employees({ text: "e" });
           setTimeout(() => {
             try {
               expect(c).toBe(3);
             } catch (e) {
-              done.fail(e)
+              done.fail(e);
             }
-            done()
+            done();
           }, 800);
         }, 400);
       }, 400);
@@ -326,27 +457,32 @@ test('debounce', done => {
   }, 200);
 });
 
-test('throttle', done => {
+test("throttle", done => {
   let c = 0;
   const throttle = f => _.throttle(f, 200);
-  const onResolve = (val) => {c += 1;};
-  const employees = createAsyncSelector({...params, onResolve, throttle}, state => state.text);
-  employees({text: 'a'});
+  const onResolve = val => {
+    c += 1;
+  };
+  const employees = createAsyncSelector(
+    { ...params, onResolve, throttle },
+    state => state.text
+  );
+  employees({ text: "a" });
   setTimeout(() => {
-    employees({text: 'b'});
+    employees({ text: "b" });
     setTimeout(() => {
-      employees({text: 'c'});
+      employees({ text: "c" });
       setTimeout(() => {
-        employees({text: 'd'});
+        employees({ text: "d" });
         setTimeout(() => {
-          employees({text: 'e'});
+          employees({ text: "e" });
           setTimeout(() => {
             try {
               expect(c).toBe(2);
             } catch (e) {
-              done.fail(e)
+              done.fail(e);
             }
-            done()
+            done();
           }, 60);
         }, 60);
       }, 60);
@@ -354,113 +490,124 @@ test('throttle', done => {
   }, 60);
 });
 
-test('throttle', done => {
+test("throttle", done => {
   let c = 0;
-  const state = {text: 'Ma'};
+  const state = { text: "Ma" };
   const throttle = f => _.throttle(f, 50);
-  const onResolve = () => {c += 1};
-  const employees = createAsyncSelector({...params, onResolve, throttle}, state => state.text);
+  const onResolve = () => {
+    c += 1;
+  };
+  const employees = createAsyncSelector(
+    { ...params, onResolve, throttle },
+    state => state.text
+  );
 
-  const expected = { 
+  const expected = {
     value: [],
-    previous: ['Mark Metzger'],
+    previous: ["Mark Metzger"],
     isWaiting: true,
     isResolved: false,
-    isRejected: false 
-  }
+    isRejected: false
+  };
 
   employees(state);
   setTimeout(() => {
-    employees({text: 'Marc'});
+    employees({ text: "Marc" });
     const result = employees(state);
     try {
       expect(deepEqual(result, expected)).toBe(true);
     } catch (e) {
-      done.fail(e)
+      done.fail(e);
     }
-    done()
-  },200)
-
+    done();
+  }, 200);
 });
 
-test('throttle', done => {
+test("throttle", done => {
   let c = 0;
-  let state = {text: 'Ma'};
+  let state = { text: "Ma" };
   const throttle = f => _.throttle(f, 50);
-  const onResolve = () => {c += 1};
-  const employees = createAsyncSelector({...params, onResolve, throttle}, state => state.text);
+  const onResolve = () => {
+    c += 1;
+  };
+  const employees = createAsyncSelector(
+    { ...params, onResolve, throttle },
+    state => state.text
+  );
 
-  const expected = { 
-    value: 'Search Text Too Long',
-    previous: ['Mark Metzger'],
+  const expected = {
+    value: "Search Text Too Long",
+    previous: ["Mark Metzger"],
     isWaiting: false,
     isResolved: false,
-    isRejected: true, 
-  }
+    isRejected: true
+  };
 
   employees(state);
   setTimeout(() => {
-    state = {text: 'aaaaaaaaaaaaaa'};
+    state = { text: "aaaaaaaaaaaaaa" };
     employees(state);
     setTimeout(() => {
       const result = employees(state);
       try {
         expect(deepEqual(result, expected)).toBe(true);
       } catch (e) {
-        done.fail(e)
+        done.fail(e);
       }
-      done()
-      
+      done();
     }, 500);
-  },200)
+  }, 200);
 });
 
-test('throttle memoization', done => {
+test("throttle memoization", done => {
   let c = 0;
-  let state = {text: 'Ma'};
+  let state = { text: "Ma" };
   const throttle = f => _.throttle(f, 50);
-  const onResolve = () => {c += 1};
-  const employees = createAsyncSelector({...params, onResolve, throttle}, state => state.text);
+  const onResolve = () => {
+    c += 1;
+  };
+  const employees = createAsyncSelector(
+    { ...params, onResolve, throttle },
+    state => state.text
+  );
 
-  const expected = { 
-    value: 'Search Text Too Long',
-    previous: ['Mark Metzger'],
+  const expected = {
+    value: "Search Text Too Long",
+    previous: ["Mark Metzger"],
     isWaiting: false,
     isResolved: false,
-    isRejected: true, 
-  }
+    isRejected: true
+  };
 
   employees(state);
   employees(state);
   employees(state);
   employees(state);
   setTimeout(() => {
-    state = {text: 'aaaaaaaaaaaaaa'};
+    state = { text: "aaaaaaaaaaaaaa" };
     employees(state);
     setTimeout(() => {
       const result = employees(state);
       try {
         expect(c).toBe(1);
       } catch (e) {
-        done.fail(e)
+        done.fail(e);
       }
       done();
     }, 500);
-  },200)
+  }, 200);
 });
 
-
 function getAges(employees, maxAge) {
-  
   return new Promise((resolve, reject) => {
     setTimeout(() => {
       const database = ["Mark Metzger", "Steven Miller"];
       const ages = [12, 34];
       if (maxAge < 3) {
-        reject('too young');
+        reject("too young");
       } else {
         const employeeAges = employees.map(name => {
-          return ages[database.indexOf(name)]
+          return ages[database.indexOf(name)];
         });
         resolve(employeeAges.filter(age => age <= maxAge));
       }
@@ -469,89 +616,91 @@ function getAges(employees, maxAge) {
 }
 
 const params2 = {
-  sync:(employees, ages) => [],
-  async: getAges,
-}
+  sync: (employees, ages) => [],
+  async: getAges
+};
 
-test('multiple params', () => {
+test("multiple params", () => {
   let c = 0;
-  let state = {employees: ['Mark Metzger'], maxAge: 40};
+  let state = { employees: ["Mark Metzger"], maxAge: 40 };
   const ages = createAsyncSelector(params2, s => s.employees, s => s.maxAge);
   const result = ages(state);
 
-  const expected = { 
+  const expected = {
     value: [],
     previous: undefined,
     isWaiting: true,
     isResolved: false,
-    isRejected: false, 
-  }
+    isRejected: false
+  };
 
   expect(deepEqual(result, expected)).toBe(true);
-  
 });
 
-test('multiple params2', done => {
+test("multiple params2", done => {
   let c = 0;
-  let state = {employees: ['Mark Metzger'], maxAge: 40};
+  let state = { employees: ["Mark Metzger"], maxAge: 40 };
   const ages = createAsyncSelector(params2, s => s.employees, s => s.maxAge);
 
-  const expected = { 
+  const expected = {
     value: [12],
     previous: [12],
     isWaiting: false,
     isResolved: true,
-    isRejected: false, 
-  }
-  
+    isRejected: false
+  };
+
   ages(state);
   setTimeout(() => {
     const result = ages(state);
     try {
       expect(deepEqual(result, expected)).toBe(true);
     } catch (e) {
-      done.fail(e)
+      done.fail(e);
     }
     done();
   }, 300);
 });
 
-test('multiple params3', done => {
+test("multiple params3", done => {
   let c = 0;
-  let state = {employees: ['Mark Metzger'], maxAge: 10};
+  let state = { employees: ["Mark Metzger"], maxAge: 10 };
   const ages = createAsyncSelector(params2, s => s.employees, s => s.maxAge);
   const result = ages(state);
 
-  const expected = { 
+  const expected = {
     value: [],
     previous: [],
     isWaiting: false,
     isResolved: true,
-    isRejected: false, 
-  }
+    isRejected: false
+  };
 
   ages(state);
   setTimeout(() => {
     const result = ages(state);
-    
+
     try {
       expect(deepEqual(result, expected)).toBe(true);
     } catch (e) {
-      done.fail(e)
+      done.fail(e);
     }
     done();
   }, 200);
 });
 
-test('debounced memoized', done => {
+test("debounced memoized", done => {
   let c = 0;
-  let state = {employees: ['Mark Metzger'], maxAge: 10};
-  const throttle = f => _.debounce(f, 100)
-  const onResolve = () => {c++}
+  let state = { employees: ["Mark Metzger"], maxAge: 10 };
+  const throttle = f => _.debounce(f, 100);
+  const onResolve = () => {
+    c++;
+  };
   const ages = createAsyncSelector(
-    {...params2, throttle, onResolve }, 
-    s => s.employees, 
-    s => s.maxAge);
+    { ...params2, throttle, onResolve },
+    s => s.employees,
+    s => s.maxAge
+  );
 
   ages(state);
   setTimeout(() => {
@@ -566,7 +715,7 @@ test('debounced memoized', done => {
             try {
               expect(c).toBe(1);
             } catch (e) {
-              done.fail(e)
+              done.fail(e);
             }
             done();
           }, 122);
@@ -576,16 +725,18 @@ test('debounced memoized', done => {
   }, 120);
 });
 
-test('debounced memoized 2', done => {
+test("debounced memoized 2", done => {
   let c = 0;
-  let state = {employees: ['Mark Metzger'], maxAge: 10};
-  const throttle = f => _.debounce(f, 100)
-  const onResolve = () => {c++}
+  let state = { employees: ["Mark Metzger"], maxAge: 10 };
+  const throttle = f => _.debounce(f, 100);
+  const onResolve = () => {
+    c++;
+  };
   const ages = createAsyncSelector(
-    {...params2, throttle, onResolve }, 
-    s => s.employees, 
-    s => s.maxAge);
-
+    { ...params2, throttle, onResolve },
+    s => s.employees,
+    s => s.maxAge
+  );
 
   ages(state);
   ages(state);
@@ -601,7 +752,7 @@ test('debounced memoized 2', done => {
             try {
               expect(c).toBe(1);
             } catch (e) {
-              done.fail(e)
+              done.fail(e);
             }
             done();
           }, 122);
@@ -611,15 +762,18 @@ test('debounced memoized 2', done => {
   }, 120);
 });
 
-test('debounced memoized 3', done => {
+test("debounced memoized 3", done => {
   let c = 0;
-  let state = {employees: ['Mark Metzger'], maxAge: 10};
-  const throttle = f => _.debounce(f, 100)
-  const onResolve = () => {c++}
+  let state = { employees: ["Mark Metzger"], maxAge: 10 };
+  const throttle = f => _.debounce(f, 100);
+  const onResolve = () => {
+    c++;
+  };
   const ages = createAsyncSelector(
-    {...params2, throttle, onResolve }, 
-    s => s.employees, 
-    s => s.maxAge);
+    { ...params2, throttle, onResolve },
+    s => s.employees,
+    s => s.maxAge
+  );
 
   ages(state);
   ages(state);
@@ -628,14 +782,14 @@ test('debounced memoized 3', done => {
     setTimeout(() => {
       ages(state);
       setTimeout(() => {
-        ages({employees: ['Mark Metzger'], maxAge: 9})
+        ages({ employees: ["Mark Metzger"], maxAge: 9 });
         setTimeout(() => {
           ages(state);
           setTimeout(() => {
             try {
               expect(c).toBe(2);
             } catch (e) {
-              done.fail(e)
+              done.fail(e);
             }
             done();
           }, 88);
@@ -645,23 +799,26 @@ test('debounced memoized 3', done => {
   }, 180);
 });
 
-test('debounced memoized 4', done => {
+test("debounced memoized 4", done => {
   let c = 0;
-  let state = {employees: ['Mark Metzger'], maxAge: 100};
-  const throttle = f => _.debounce(f, 100)
-  const onResolve = () => {c++}
+  let state = { employees: ["Mark Metzger"], maxAge: 100 };
+  const throttle = f => _.debounce(f, 100);
+  const onResolve = () => {
+    c++;
+  };
   const ages = createAsyncSelector(
-    {...params2, throttle, onResolve }, 
-    s => s.employees, 
-    s => s.maxAge);
+    { ...params2, throttle, onResolve },
+    s => s.employees,
+    s => s.maxAge
+  );
 
-  const expected = { 
+  const expected = {
     value: [],
     previous: [],
     isWaiting: false,
     isResolved: true,
-    isRejected: false, 
-  }
+    isRejected: false
+  };
 
   ages(state);
   ages(state);
@@ -670,7 +827,7 @@ test('debounced memoized 4', done => {
     setTimeout(() => {
       ages(state);
       setTimeout(() => {
-        const n = {employees: ['Mark Metzger'], maxAge: 9};
+        const n = { employees: ["Mark Metzger"], maxAge: 9 };
         ages(n);
         setTimeout(() => {
           ages(state);
@@ -679,7 +836,7 @@ test('debounced memoized 4', done => {
             try {
               expect(deepEqual(expected, result)).toBe(true);
             } catch (e) {
-              done.fail(e)
+              done.fail(e);
             }
             done();
           }, 88);
@@ -689,24 +846,26 @@ test('debounced memoized 4', done => {
   }, 180);
 });
 
-
-test('debounced memoized 5', done => {
+test("debounced memoized 5", done => {
   let c = 0;
-  let state = {employees: ['Mark Metzger'], maxAge: 10};
-  const throttle = f => _.debounce(f, 100)
-  const onResolve = () => {c++}
+  let state = { employees: ["Mark Metzger"], maxAge: 10 };
+  const throttle = f => _.debounce(f, 100);
+  const onResolve = () => {
+    c++;
+  };
   const ages = createAsyncSelector(
-    {...params2, throttle, onResolve }, 
-    s => s.employees, 
-    s => s.maxAge);
+    { ...params2, throttle, onResolve },
+    s => s.employees,
+    s => s.maxAge
+  );
 
-  const expected = { 
+  const expected = {
     value: [],
     previous: [12],
     isWaiting: true,
     isResolved: false,
-    isRejected: false, 
-  }
+    isRejected: false
+  };
 
   ages(state);
   ages(state);
@@ -715,16 +874,16 @@ test('debounced memoized 5', done => {
     setTimeout(() => {
       ages(state);
       setTimeout(() => {
-        const n = {employees: ['Mark Metzger'], maxAge: 20};
+        const n = { employees: ["Mark Metzger"], maxAge: 20 };
         ages(n);
         setTimeout(() => {
           ages(state);
           setTimeout(() => {
-            const result = ages({employees: ['Mark Metzger'], maxAge: 20});
+            const result = ages({ employees: ["Mark Metzger"], maxAge: 20 });
             try {
               expect(deepEqual(expected, result)).toBe(true);
             } catch (e) {
-              done.fail(e)
+              done.fail(e);
             }
             done();
           }, 88);
@@ -734,71 +893,83 @@ test('debounced memoized 5', done => {
   }, 180);
 });
 
-test('cancel result', () => {
-  let state = {employees: ['Mark Metzger'], maxAge: 10};
-  let result = null
-  const onCancel = (promise, n, a) => {result=[n,a]}
+test("cancel result", () => {
+  let state = { employees: ["Mark Metzger"], maxAge: 10 };
+  let result = null;
+  const onCancel = (promise, n, a) => {
+    result = [n, a];
+  };
   const ages = createAsyncSelector(
-    {...params2, onCancel }, 
-    s => s.employees, 
-    s => s.maxAge);
+    { ...params2, onCancel },
+    s => s.employees,
+    s => s.maxAge
+  );
 
   ages(state);
-  ages({employees: ['Mark Metzger'], maxAge: 11});
-  expect(deepEqual(result, [['Mark Metzger'], 10])).toBe(true);
+  ages({ employees: ["Mark Metzger"], maxAge: 11 });
+  expect(deepEqual(result, [["Mark Metzger"], 10])).toBe(true);
 });
 
-test('resolve result', done => {
-  let state = {employees: ['Mark Metzger'], maxAge: 10};
-  let result = null
-  const onResolve = (r, n, a) => {result=[r,n,a]}
+test("resolve result", done => {
+  let state = { employees: ["Mark Metzger"], maxAge: 10 };
+  let result = null;
+  const onResolve = (r, n, a) => {
+    result = [r, n, a];
+  };
   const ages = createAsyncSelector(
-    {...params2, onResolve }, 
-    s => s.employees, 
-    s => s.maxAge);
+    { ...params2, onResolve },
+    s => s.employees,
+    s => s.maxAge
+  );
 
   ages(state);
   ages(state);
   setTimeout(() => {
     try {
-      expect(deepEqual(result, [[], ['Mark Metzger'], 10])).toBe(true);
+      expect(deepEqual(result, [[], ["Mark Metzger"], 10])).toBe(true);
     } catch (e) {
-      done.fail(e)
+      done.fail(e);
     }
     done();
   }, 200);
 });
 
-test('reject result', done => {
-  let state = {employees: ['Mark Metzger'], maxAge: 1};
-  let result = null
-  const onReject = (r, n, a) => {result=[r,n,a]}
+test("reject result", done => {
+  let state = { employees: ["Mark Metzger"], maxAge: 1 };
+  let result = null;
+  const onReject = (r, n, a) => {
+    result = [r, n, a];
+  };
   const ages = createAsyncSelector(
-    {...params2, onReject }, 
-    s => s.employees, 
-    s => s.maxAge);
+    { ...params2, onReject },
+    s => s.employees,
+    s => s.maxAge
+  );
 
   ages(state);
   ages(state);
   setTimeout(() => {
     try {
-      expect(deepEqual(result, ['too young', ['Mark Metzger'], 1])).toBe(true);
+      expect(deepEqual(result, ["too young", ["Mark Metzger"], 1])).toBe(true);
     } catch (e) {
-      done.fail(e)
+      done.fail(e);
     }
     done();
   }, 200);
 });
 
-test('throttled and forced', done => {
-  let state = {employees: ['Mark Metzger'], maxAge: 1};
-  let result = null
+test("throttled and forced", done => {
+  let state = { employees: ["Mark Metzger"], maxAge: 1 };
+  let result = null;
   const throttle = f => _.debounce(f, 150);
-  const onCancel = (r, n, a) => {result=[r,n,a]}
+  const onCancel = (r, n, a) => {
+    result = [r, n, a];
+  };
   const ages = createAsyncSelector(
-    {...params2, throttle, onCancel}, 
-    s => s.employees, 
-    s => s.maxAge);
+    { ...params2, throttle, onCancel },
+    s => s.employees,
+    s => s.maxAge
+  );
 
   ages(state);
   ages.forceUpdate(state);
@@ -807,91 +978,90 @@ test('throttled and forced', done => {
     try {
       expect(deepEqual(result, null)).toBe(true);
     } catch (e) {
-      done.fail(e)
+      done.fail(e);
     }
     done();
   }, 200);
 });
 
-test('Throw error', () => {
+test("Throw error", () => {
   try {
     createAsyncSelector();
   } catch (e) {
-    expect(e.message).toBe('An object of parameters must be passed in');
+    expect(e.message).toBe("An object of parameters must be passed in");
   }
 });
 
-test('selector.getResult', done => {
+test("selector.getResult", done => {
   let c = 0;
-  let state = {employees: ['Mark Metzger'], maxAge: 10};
+  let state = { employees: ["Mark Metzger"], maxAge: 10 };
   const ages = createAsyncSelector(params2, s => s.employees, s => s.maxAge);
   const result = ages(state);
 
-  const expected = { 
+  const expected = {
     value: [],
     previous: [],
     isWaiting: false,
     isResolved: true,
-    isRejected: false, 
-  }
+    isRejected: false
+  };
 
   ages(state);
   setTimeout(() => {
-    
     try {
       expect(deepEqual(ages.getResult(), expected)).toBe(true);
     } catch (e) {
-      done.fail(e)
+      done.fail(e);
     }
     done();
   }, 200);
 });
 
-
-test('debounces only memoized version', done => {
-  let state = {employees: ['Mark Metzger'], maxAge: 15};
-  let result = null
+test("debounces only memoized version", done => {
+  let state = { employees: ["Mark Metzger"], maxAge: 15 };
+  let result = null;
   const throttle = f => _.debounce(f, 150);
   const ages = createAsyncSelector(
-    {...params2, throttle}, 
-    s => s.employees, 
-    s => s.maxAge);
+    { ...params2, throttle },
+    s => s.employees,
+    s => s.maxAge
+  );
 
-  const expected1 = { 
+  const expected1 = {
     value: [],
     previous: undefined,
     isWaiting: true,
     isResolved: false,
-    isRejected: false, 
-  }
+    isRejected: false
+  };
 
-  const expected2 = { 
+  const expected2 = {
     value: [12],
     previous: [12],
     isWaiting: false,
     isResolved: true,
-    isRejected: false, 
-  }
+    isRejected: false
+  };
 
   const result1 = ages(state);
-  console.log({result1});
+  console.log({ result1 });
   expect(deepEqual(result1, expected1)).toBe(true);
 
   setTimeout(() => {
     const result2 = ages(state);
-    console.log({result2});
+    console.log({ result2 });
     expect(deepEqual(result2, expected1)).toBe(true);
     setTimeout(() => {
       const result3 = ages(state);
-      console.log({result3});
+      console.log({ result3 });
       expect(deepEqual(result3, expected1)).toBe(true);
       setTimeout(() => {
         const result4 = ages(state);
-        console.log({result4});
+        console.log({ result4 });
         expect(deepEqual(result4, expected2)).toBe(true);
         setTimeout(() => {
           const result5 = ages(state);
-          console.log({result5});
+          console.log({ result5 });
           expect(deepEqual(result5, expected2)).toBe(true);
           done();
         }, 100);
@@ -900,54 +1070,54 @@ test('debounces only memoized version', done => {
   }, 100);
 });
 
+test("sync by default returns undefined", done => {
+  let state = { employees: ["Mark Metzger"], maxAge: 15 };
+  const ages = createAsyncSelector({ ...params2, sync: null }, [
+    s => s.employees,
+    s => s.maxAge
+  ]);
 
-test('sync by default returns undefined', done => {
-  let state = {employees: ['Mark Metzger'], maxAge: 15};
-  const ages = createAsyncSelector(
-    {...params2, sync: null}, 
-    [s => s.employees, 
-    s => s.maxAge]);
-
-  const expected1 = { 
+  const expected1 = {
     value: undefined,
     previous: undefined,
     isWaiting: true,
     isResolved: false,
-    isRejected: false, 
-  }
+    isRejected: false
+  };
 
   const result = ages(state);
   expect(deepEqual(result, expected1)).toBe(true);
   done();
 });
 
-
-test('passed in state and props', done => {
-  let state = {employees: ['Mark Metzger'], maxAge: 15};
-  let props = { id: 'wow' };
+test("passed in state and props", done => {
+  let state = { employees: ["Mark Metzger"], maxAge: 15 };
+  let props = { id: "wow" };
   const ages = createAsyncSelector(
     {
-      async: (concat) => new Promise((resolve) => {
-        resolve(concat + '!');
-      }),
-    }, 
-    [(s, props) => s.maxAge + props.id]);
+      async: concat =>
+        new Promise(resolve => {
+          resolve(concat + "!");
+        })
+    },
+    [(s, props) => s.maxAge + props.id]
+  );
 
-  const expected1 = { 
+  const expected1 = {
     value: undefined,
     previous: undefined,
     isWaiting: true,
     isResolved: false,
-    isRejected: false, 
-  }
+    isRejected: false
+  };
 
-  const expected2 = { 
-    value: '15wow!',
-    previous: '15wow!',
+  const expected2 = {
+    value: "15wow!",
+    previous: "15wow!",
     isWaiting: false,
     isResolved: true,
-    isRejected: false, 
-  }
+    isRejected: false
+  };
 
   const result = ages(state, props);
   expect(deepEqual(result, expected1)).toBe(true);

--- a/src/index.js
+++ b/src/index.js
@@ -1,118 +1,168 @@
 function validateParams(params) {
-    if (typeof params !== 'object' || params === null) {
-        throw new Error('An object of parameters must be passed in');
-    }
-    if (typeof params.async !== 'function') {
-        throw new Error('Looking for a function called "async". This function returns a promise which handles asynchronous code');
-    }
+  if (typeof params !== "object" || params === null) {
+    throw new Error("An object of parameters must be passed in");
+  }
+  if (typeof params.async !== "function") {
+    throw new Error(
+      'Looking for a function called "async". This function returns a promise which handles asynchronous code'
+    );
+  }
 }
 
 function hasChanged(oldValues, newValues) {
-    if (oldValues === null) return true;
-    if (oldValues.length !== newValues.length) return true;
-    for (let i = 0; i < oldValues.length; i++) {
-        if (newValues[i] !== oldValues[i]) {
-            return true;
-        }
+  if (oldValues === null) return true;
+  if (oldValues.length !== newValues.length) return true;
+  for (let i = 0; i < oldValues.length; i++) {
+    if (newValues[i] !== oldValues[i]) {
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
-function createResultObject(value, previous, isWaiting, isResolved, isRejected, omitStatus) {
-    if (omitStatus) return value;
-    return {value, previous, isWaiting, isResolved, isRejected};
+function createResultObject(
+  value,
+  previous,
+  isWaiting,
+  isResolved,
+  isRejected,
+  omitStatus
+) {
+  if (omitStatus) return value;
+  return { value, previous, isWaiting, isResolved, isRejected };
 }
 
 const emptyFunction = () => {};
 
 function createAsyncSelector(params, ...selectors) {
-    validateParams(params);
+  validateParams(params);
 
+  // if they passed in an array
+  if (selectors.length === 1 && Array.isArray(selectors[0])) {
+    selectors = selectors[0];
+  }
 
-    // if they passed in an array
-    if (selectors.length === 1 && Array.isArray(selectors[0])) {
-        selectors = selectors[0];
-    } 
+  // User inputs
+  let {
+    sync,
+    async,
+    onReject,
+    onResolve,
+    onCancel,
+    onFulfill,
+    shouldUseAsync,
+    omitStatus,
+    throttle
+  } = params;
+  sync = typeof sync === "function" ? sync : emptyFunction;
+  onReject = typeof onReject === "function" ? onReject : emptyFunction;
+  onResolve = typeof onResolve === "function" ? onResolve : emptyFunction;
+  onFulfill = typeof onFulfill === "function" ? onFulfill : emptyFunction;
+  onCancel = typeof onCancel === "function" ? onCancel : emptyFunction;
+  shouldUseAsync =
+    typeof shouldUseAsync === "function" ? shouldUseAsync : () => true;
+  omitStatus = omitStatus === void 0 ? false : omitStatus;
+  throttle = typeof throttle === "function" ? throttle : null;
 
-    // User inputs
-    let {sync, async, onReject, onResolve, onCancel, onFulfill, shouldUseAsync, omitStatus, throttle} = params;
-    sync = typeof sync === 'function' ? sync : emptyFunction;
-    onReject = typeof onReject === 'function' ? onReject : emptyFunction;
-    onResolve = typeof onResolve === 'function' ? onResolve : emptyFunction;
-    onFulfill = typeof onFulfill === 'function' ? onFulfill : emptyFunction;
-    onCancel = typeof onCancel === 'function' ? onCancel : emptyFunction;
-    shouldUseAsync = typeof shouldUseAsync === 'function' ? shouldUseAsync : () => true;
-    omitStatus = omitStatus === (void 0) ? false : omitStatus;
-    throttle = typeof throttle === 'function' ? throttle : null;
+  //selector state
+  let memoizedResult = null;
+  let isPromisePending = false;
+  let oldInputs = null;
+  let previousResolution = void 0;
+  let f = null;
 
-    //selector state
-    let memoizedResult = null;
-    let isPromisePending = false;
-    let oldInputs = null;
-    let previousResolution = void 0;
-    let f = null;
-
-    const func = (state, props, forceUpdate = false, internal = false) => {
-        const mapped = selectors.map(f => f(state, props));
-        const changed = forceUpdate || hasChanged(oldInputs, mapped);
-        if (changed) {
-            /*  Handle throttling / debouncing if required */
-            if (f !== null && internal === false) {
-                f(state, props, forceUpdate);
-                memoizedResult = createResultObject(sync(...mapped), previousResolution, true, false, false, omitStatus);
-                return memoizedResult;
-            }
-            /* //////////////////////////////////////////// */
-            
-            if (isPromisePending) {
-                onCancel(promise, ...oldInputs);
-            }
-            oldInputs = mapped;
-
-            memoizedResult = createResultObject(sync(...mapped), previousResolution, true, false, false, omitStatus);
-            
-            if (!shouldUseAsync(...mapped)) {
-                return memoizedResult;
-            }
-            const promise = params.async(...mapped);
-            isPromisePending = true;
-            promise.then((promiseResolution) => {
-                if (!hasChanged(oldInputs, mapped)) {
-                    previousResolution = promiseResolution;
-                    isPromisePending = false;
-                    memoizedResult = createResultObject(promiseResolution, previousResolution, false, true, false, omitStatus);
-                    onResolve(promiseResolution, ...mapped);
-                }
-                onFulfill(promiseResolution, ...mapped);
-            }).catch((promiseRejection) => {
-                console.log(promiseRejection);
-                if (!hasChanged(oldInputs, mapped)) {
-                    isPromisePending = false;
-                    memoizedResult = createResultObject(promiseRejection, previousResolution, false, false, true, omitStatus);
-                    onReject(promiseRejection, ...mapped);
-                }
-                onFulfill(promiseRejection, ...mapped);
-            })
-		}
-		// If the inputs didn't change, simply return the old memoized result
+  const func = (state, props, forceUpdate = false, internal = false) => {
+    const mapped = selectors.map(f => f(state, props));
+    const changed = forceUpdate || hasChanged(oldInputs, mapped);
+    if (changed) {
+      /*  Handle throttling / debouncing if required */
+      if (f !== null && internal === false) {
+        f(state, props, forceUpdate);
+        memoizedResult = createResultObject(
+          sync(...mapped),
+          previousResolution,
+          true,
+          false,
+          false,
+          omitStatus
+        );
         return memoizedResult;
+      }
+      /* //////////////////////////////////////////// */
+
+      if (isPromisePending) {
+        onCancel(promise, ...oldInputs);
+      }
+      oldInputs = mapped;
+
+      memoizedResult = createResultObject(
+        sync(...mapped),
+        previousResolution,
+        true,
+        false,
+        false,
+        omitStatus
+      );
+
+      if (!shouldUseAsync(...mapped)) {
+        return memoizedResult;
+      }
+      const promise = params.async(...mapped);
+      isPromisePending = true;
+      promise
+        .then(promiseResolution => {
+          if (!hasChanged(oldInputs, mapped)) {
+            previousResolution = promiseResolution;
+            isPromisePending = false;
+            memoizedResult = createResultObject(
+              promiseResolution,
+              previousResolution,
+              false,
+              true,
+              false,
+              omitStatus
+            );
+            onResolve(promiseResolution, ...mapped);
+          }
+          onFulfill(promiseResolution, ...mapped);
+        })
+        .catch(promiseRejection => {
+          if (!hasChanged(oldInputs, mapped)) {
+            isPromisePending = false;
+            memoizedResult = createResultObject(
+              promiseRejection,
+              previousResolution,
+              false,
+              false,
+              true,
+              omitStatus
+            );
+            onReject(promiseRejection, ...mapped);
+          }
+          onFulfill(promiseRejection, ...mapped);
+        });
+    }
+    // If the inputs didn't change, simply return the old memoized result
+    return memoizedResult;
+  };
+  if (throttle !== null && f === null) {
+    const throttled = throttle((state, props) =>
+      func(state, props, true, true)
+    );
+    let old = null;
+    f = (state, props) => {
+      const New = selectors.map(s => s(state, props));
+      if (hasChanged(old, New)) {
+        old = New;
+        throttled(state, props);
+      }
     };
-    if (throttle !== null && f === null) {
-        const throttled = throttle((state, props) => func(state, props, true, true));
-        let old = null;
-        f = (state, props) => {
-            const New = selectors.map(s => s(state, props));
-            if (hasChanged(old, New)) {
-                old = New;
-                throttled(state, props);
-            }
-        }
-    }
-    func.forceUpdate = (state, props) => {
-        return func(state, props, true, false);
-    }
-    func.getResult = () => memoizedResult;
-    return func;
+  }
+  func.forceUpdate = (state, props) => {
+    return func(state, props, true, false);
+  };
+  func.getResult = () => memoizedResult;
+  return func;
 }
 
 export default createAsyncSelector;

--- a/src/index.js
+++ b/src/index.js
@@ -35,10 +35,11 @@ function createAsyncSelector(params, ...selectors) {
     } 
 
     // User inputs
-    let {sync, async, onReject, onResolve, onCancel, shouldUseAsync, omitStatus, throttle} = params;
+    let {sync, async, onReject, onResolve, onCancel, onFulfill, shouldUseAsync, omitStatus, throttle} = params;
     sync = typeof sync === 'function' ? sync : emptyFunction;
     onReject = typeof onReject === 'function' ? onReject : emptyFunction;
     onResolve = typeof onResolve === 'function' ? onResolve : emptyFunction;
+    onFulfill = typeof onFulfill === 'function' ? onFulfill : emptyFunction;
     onCancel = typeof onCancel === 'function' ? onCancel : emptyFunction;
     shouldUseAsync = typeof shouldUseAsync === 'function' ? shouldUseAsync : () => true;
     omitStatus = omitStatus === (void 0) ? false : omitStatus;
@@ -80,14 +81,17 @@ function createAsyncSelector(params, ...selectors) {
                     previousResolution = promiseResolution;
                     isPromisePending = false;
                     memoizedResult = createResultObject(promiseResolution, previousResolution, false, true, false, omitStatus);
-                    onResolve(promiseResolution, ...mapped)
+                    onResolve(promiseResolution, ...mapped);
                 }
+                onFulfill(promiseResolution, ...mapped);
             }).catch((promiseRejection) => {
+                console.log(promiseRejection);
                 if (!hasChanged(oldInputs, mapped)) {
                     isPromisePending = false;
                     memoizedResult = createResultObject(promiseRejection, previousResolution, false, false, true, omitStatus);
-                    onReject(promiseRejection, ...mapped)
+                    onReject(promiseRejection, ...mapped);
                 }
+                onFulfill(promiseRejection, ...mapped);
             })
 		}
 		// If the inputs didn't change, simply return the old memoized result


### PR DESCRIPTION
This pull requests add a new `onFulfill` use case in the params which is called _after_ the promise is either resolved or rejected. This results in much re-renders.

Code can go from
```javascript
const params2 = {
  sync: (employees) => [],
  async: getAgesForEmployees,
  onResolve: (ages, employees) => store.dispatch(triggerRerender()),
  onReject: (ages, employees) => store.dispatch(triggerRerender()),
  onCancel: (promise, employees) => promise.cancel(),
  shouldUseAsync: (employees) => employees.isResolved === true,
}
```
to: 

```javascript
const params2 = {
  async: getAgesForEmployees,
  onFulfill: (ages, employees) => store.dispatch(triggerRerender()),
}

```

